### PR TITLE
Add "Static Analysis" GitHub workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,42 @@
+name: "Static Analysis"
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  static-analysis:
+    name: "Static Analysis"
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+        composer-dependency-versions:
+          - "lowest"
+          - "highest"
+
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@v4"
+
+      - name: "Setup PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          coverage: "none"
+
+      - name: "Install dependencies (Composer)"
+        uses: "ramsey/composer-install@v2"
+        with:
+          dependency-versions: "${{ matrix.composer-dependency-versions }}"
+
+      - name: "Analyze code using PHP_CodeSniffer"
+        run: "vendor/bin/phpcs"
+
+      - name: "Analyze code using PHPStan"
+        run: "vendor/bin/phpstan"

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require-dev": {
         "composer/composer": "^2.0",
         "isaac/php-code-sniffer-standard": "^28.2.0",
+        "slevomat/coding-standard": "^7.1.0 || ^8.0",
         "phpstan/extension-installer": "^1.2.0",
         "phpstan/phpstan": "^1.10.1",
         "phpstan/phpstan-strict-rules": "^1.5.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0abeb619b942ad90d964714dfda7b9f",
+    "content-hash": "3204d3c7d2e63c71dae1dadbe31f2671",
     "packages": [],
     "packages-dev": [
         {
@@ -763,6 +763,7 @@
                 "issues": "https://github.com/isaaceindhoven/php-code-sniffer-standard",
                 "source": "https://github.com/isaaceindhoven/php-code-sniffer-standard/tree/v28.2.0"
             },
+            "abandoned": "iodigital-com/php-code-sniffer-standard",
             "time": "2022-11-04T10:56:37+00:00"
         },
         {

--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -28,7 +28,10 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
         // noop
     }
 
-    /** @inheritDoc */
+    /**
+     * @inheritDoc
+     * @return array<string, string|array{0: string, 1?: int}|array<array{0: string, 1?: int}>>
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -68,7 +68,6 @@ class FileSystem
         return $projectRoot;
     }
 
-    // phpcs:ignore ObjectCalisthenics.Files.FunctionLength.ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff
     public function getRelativePath(string $from, string $to): string
     {
         // some compatibility fixes for Windows paths


### PR DESCRIPTION
Add GitHub workflow that performs PHP_CodeSniffer and PHPStan analysis for all supported PHP versions and the highest and lowest possible Composer dependencies.